### PR TITLE
fix: uwb webcam url unreachable

### DIFF
--- a/neilbot/cogs/photo.py
+++ b/neilbot/cogs/photo.py
@@ -85,7 +85,7 @@ class Photo(commands.Cog):
             ctx (discord.ApplicationContext): the Discord application context
         """
         # save the URL used for accessing the UWB webcam
-        UWB_WEBCAM_URL = "http://69.91.192.220/netcam.jpg"
+        UWB_WEBCAM_URL = "https://camera.uwb.edu/netcam.jpg"
 
         # give us 15 minutes instead of 3 seconds to respond
         await ctx.defer(ephemeral=False)


### PR DESCRIPTION
The address for the webcam changed, this updates to the new URL. This is the page where the URL can be found: www.uwb.edu/about/webcam