### PR TITLE
Enable Renovate pre-commit manager explicitly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "enabledManagers": ["poetry", "pre-commit", "github-actions"],
+  "pre-commit": {
+    "enabled": true
+  },
   "labels": ["dependencies"],
   "dependencyDashboard": true,
   "timezone": "America/Los_Angeles",


### PR DESCRIPTION
## Summary
Enable Renovate pre-commit manager explicitly in .github/renovate.json.

## Why this change
Renovate pre-commit support is in beta and disabled by default, so this repo must opt in to ensure .pre-commit-config.yaml updates are detected and processed.

Docs: https://docs.renovatebot.com/modules/manager/pre-commit/

## Notes
The Renovate docs also note behavior may differ from pre-commit autoupdate while this manager is in beta, so update behavior can vary from native pre-commit tooling.