### PR TITLE
Split Python version bumps into a dedicated Renovate PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,21 @@
   "schedule": ["before 5am on saturday"],
   "packageRules": [
     {
+      "matchManagers": ["poetry"],
+      "matchPackageNames": ["python"],
+      "groupName": "python runtime version",
+      "prBodyNotes": [
+        "Manual follow-ups for Python runtime bumps:",
+        "- [ ] Update `project.requires-python` in `pyproject.toml`",
+        "- [ ] Update `tool.black.target-version` in `pyproject.toml`",
+        "- [ ] Update `tool.mypy.python_version` in `pyproject.toml`",
+        "- [ ] Update `--py310-plus` (or equivalent) in `.pre-commit-config.yaml`",
+        "- [ ] Update `FROM python:...` in `Dockerfile`"
+      ]
+    },
+    {
       "matchManagers": ["poetry", "pre-commit"],
+      "excludePackageNames": ["python"],
       "groupName": "pre-commit hooks"
     }
   ]


### PR DESCRIPTION
## Summary
This change separates Poetry's python dependency updates into their own Renovate PR and adds a checklist in the PR body for related manual follow-ups.

## Why we want this
A recent Renovate PR bumped Poetry's python constraint together with other dependency updates. That caused lockfile artifact update failure when dependency constraints became incompatible.

Separating python version bumps makes these runtime changes explicit and reviewable on their own.

## What Renovate can bump automatically
- Poetry python dependency constraint in pyproject (tool.poetry.dependencies.python)

## What still needs manual bumps
- project.requires-python in pyproject
- tool.black.target-version in pyproject
- tool.mypy.python_version in pyproject
- pyupgrade target flag in .pre-commit-config.yaml (for example --py310-plus)
- Docker base image tag in Dockerfile (FROM python:...)

## Why the checklist was added
The dedicated Python PR now includes a markdown checklist (prBodyNotes) so reviewers can track these manual follow-ups whenever python runtime is bumped.