### PR TITLE
fix: keep python runtime bumps out of pre-commit grouped updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
   "packageRules": [
     {
       "matchManagers": ["poetry"],
-      "matchPackageNames": ["python"],
+      "matchDepNames": ["python"],
       "groupName": "python runtime version",
       "prBodyNotes": [
         "Manual follow-ups for Python runtime bumps:",
@@ -26,7 +26,7 @@
     },
     {
       "matchManagers": ["poetry", "pre-commit"],
-      "excludePackageNames": ["python"],
+      "excludeDepNames": ["python"],
       "groupName": "pre-commit hooks"
     }
   ]


### PR DESCRIPTION
## Why this fix is needed
Renovate is still including the Poetry python update inside the grouped pre-commit hooks PR. This mixes runtime-version changes with tooling updates and can lead to confusing or failing artifact updates.

The observed dependency shape in logs is:
- depName: python
- packageName: containerbase/python-prebuild

Because of that mismatch, package-name filtering does not reliably exclude the Python runtime update from the grouped PR.

## What this change does
- Switches Python matching to matchDepNames: ["python"] for the dedicated Python rule.
- Switches grouped-rule exclusion to excludeDepNames: ["python"].

This keeps Python runtime bumps in their dedicated PR and prevents them from being pulled into the grouped pre-commit/poetry update PR.