### PR TITLE
chore: constrain Poetry Python to 3.10.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = ["Neil Wiborg <NeilWiborg@outlook.com>"]
 neilbot = "main:main"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "~3.10"
 py-cord = { extras = ["voice"], version = "^2.6.1" }
 python-dotenv = "^1.2.1"
 validators = "^0.35.0"


### PR DESCRIPTION
## Summary
Update Poetry Python constraint from ^3.10 to ~3.10.

## Why
^3.10 allows Python 3.14+, which conflicts with dependencies like py-cord that currently require <3.14.

Using ~3.10 constrains installs to any 3.10.x release (>=3.10,<3.11), while still allowing patch-level Python updates.

## Impact
- Reduces lockfile/artifact update failures caused by incompatible Python major/minor resolution.
- Keeps runtime within the currently supported 3.10 line.