### PR TITLE
fix: trailing comma in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     -   id: flake8
         language: python
         additional_dependencies:
-        -   flake8-pyproject==1.2.3,
+        -   flake8-pyproject==1.2.3
         -   mccabe==0.7.0
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.19.1


### PR DESCRIPTION
I accidentally had a trailing comma