### PR TITLE
chore: add poetry pre-commit hook

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,6 +34,7 @@
         "- [ ] Update `project.requires-python` in `pyproject.toml`",
         "- [ ] Update `tool.black.target-version` in `pyproject.toml`",
         "- [ ] Update `tool.mypy.python_version` in `pyproject.toml`",
+        "- [ ] Update `default_language_version.python` in `.pre-commit-config.yaml`",
         "- [ ] Update `--py310-plus` (or equivalent) in `.pre-commit-config.yaml`",
         "- [ ] Update `FROM python:...` in `Dockerfile`"
       ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  python: python3.10
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 default_language_version:
   python: python3.10
 
+ci:
+  skip:
+  - poetry-lock
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,9 @@ repos:
         language: python
         additional_dependencies:
         -   tomli
+-   repo: https://github.com/python-poetry/poetry
+    rev: 2.3.2
+    hooks:
+    -   id: poetry-check
+        args: ["--lock"]
+    -   id: poetry-lock


### PR DESCRIPTION
I frequently forget to update the lockfile, and only find out when the CI deploy stage fails. This adds a pre-commit hook to validate the poetry config and lockfile.