### PR TITLE
chore: update pyproject config

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1962,5 +1962,5 @@ test = ["pytest (>=8.1,<9.0)", "pytest-rerunfailures (>=14.0,<15.0)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "~3.10"
-content-hash = "70efe9f6df2bbe5e771fc5ce54aadc44f41dedd0bb9551023fc1f1c774eb23e8"
+python-versions = ">=3.10,<3.11"
+content-hash = "a21c2c5a7e72e158d18e8bbf029a114fe5e90c69cc208b814bbc98f00c9a813a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,42 +2,42 @@
 name = "NeilBot"
 version = "0.0.1"
 description = "A Discord bot made by Neil."
-license = { file = "LICENSE" }
-readme = "README.md"
-requires-python = ">=3.10"
-
-[tool.poetry]
-name = "NeilBot"
-version = "0.0.1"
-description = "A Discord bot made by Neil."
+authors = [{ name = "Neil Wiborg", email = "NeilWiborg@outlook.com" }]
 license = "GPL-3.0-only"
-authors = ["Neil Wiborg <NeilWiborg@outlook.com>"]
+license-files = ["LICENSE"]
+readme = "README.md"
+requires-python = ">=3.10,<3.11"
+dependencies = [
+    "py-cord[voice]==2.7.1",
+    "python-dotenv==1.2.2",
+    "validators==0.35.0",
+    "apscheduler==3.11.2",
+    "pymongo[srv]==4.16.0",
+    "yt-dlp==2026.3.3",
+    "aiohttp==3.13.3",
+]
 
-[tool.poetry.scripts]
+[dependency-groups]
+dev = [
+    "pyupgrade==3.21.2",
+    "autoflake==2.3.3",
+    "isort==8.0.1",
+    "flake8==7.3.0",
+    "flake8-pyproject==1.2.4",
+    "mccabe==0.7.0",
+    "mypy==1.19.1",
+    "vulture==2.14",
+    "codespell==2.4.2",
+    "pre-commit==4.5.1",
+    "black==26.3.0",
+]
+
+[build-system]
+requires = ["poetry-core==2.3.2"]
+build-backend = "poetry.core.masonry.api"
+
+[project.scripts]
 neilbot = "main:main"
-
-[tool.poetry.dependencies]
-python = "~3.10"
-py-cord = { extras = ["voice"], version = "^2.7.1" }
-python-dotenv = "^1.2.2"
-validators = "^0.35.0"
-apscheduler = "^3.11.2"
-pymongo = { extras = ["srv"], version = "^4.16.0" }
-yt-dlp = "^2026.3.3"
-aiohttp = "^3.13.3"
-
-[tool.poetry.group.dev.dependencies]
-pyupgrade = "^3.21.2"
-autoflake = "^2.3.3"
-isort = "^8.0.1"
-flake8 = "^7.3.0"
-flake8-pyproject = "^1.2.4"
-mccabe = "^0.7.0"
-mypy = "^1.19.1"
-vulture = "^2.14"
-codespell = "^2.4.2"
-pre-commit = "^4.5.1"
-black = "^26.3.0"
 
 [tool.black]
 target-version = ["py310"]


### PR DESCRIPTION
The current version of Poetry was warning me about deprecated fields in my pyproject config:
```
󱐋  mainline [$?] NeilBot❯poetry check --lock
Warning: Defining [project.license] as a table is deprecated. [project.license] should be a valid SPDX license expression. License files can be referenced in [project.license-files].
Warning: [project.name] and [tool.poetry.name] are both set. The latter will be ignored.
Warning: [project.version] and [tool.poetry.version] are both set. The latter will be ignored.
If you want to set the version dynamically via `poetry build --local-version` or you are using a plugin, which sets the version dynamically, you should define the version in [tool.poetry] and add 'version' to [project.dynamic].
Warning: [project.description] and [tool.poetry.description] are both set. The latter will be ignored.
Warning: [project.license] and [tool.poetry.license] are both set. The latter will be ignored.
Warning: [tool.poetry.authors] is deprecated. Use [project.authors] instead.
Warning: Defining console scripts in [tool.poetry.scripts] is deprecated. Use [project.scripts] instead. ([tool.poetry.scripts] should only be used for scripts of type 'file').
Warning: [tool.poetry.dependencies] is set but [project.dependencies] is not and 'dependencies' is not in [project.dynamic]. You should either migrate [tool.poetry.dependencies] to [project.dependencies] (if you do not need Poetry-specific features) or add [project.dependencies] in addition to [tool.poetry.dependencies] or add 'dependencies' to [project.dynamic].
```

This migrates to a more modern config. See the docs here: https://python-poetry.org/docs/pyproject/

I no longer get any deprecation warnings:
```
󱐋  nwiborg/update-pyproject [!] NeilBot❯poetry check --lock
All set!
```