### PR TITLE
chore: disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
I now have Renovate setup, so I don't need autobumps from Dependabot anymore.